### PR TITLE
Specify specific GitHub branch to run scripts from

### DIFF
--- a/install_pro.sh
+++ b/install_pro.sh
@@ -758,7 +758,7 @@ WATCHDOG_INSTALL="1"
 echo -e "${ARROW} ${YELLOW}Downloading...${NC}"
 cd && git clone https://github.com/RunOnFlux/fluxnode-watchdog.git watchdog > /dev/null 2>&1
 echo -e "${ARROW} ${YELLOW}Installing git hooks....${NC}"
-wget https://raw.githubusercontent.com/RunOnFlux/fluxnode-multitool/master/post-merge > /dev/null 2>&1
+wget https://raw.githubusercontent.com/RunOnFlux/fluxnode-multitool/$ROOT_BRANCH/post-merge > /dev/null 2>&1
 mv post-merge /home/$USER/watchdog/.git/hooks/post-merge
 sudo chmod +x /home/$USER/watchdog/.git/hooks/post-merge
 echo -e "${ARROW} ${YELLOW}Installing watchdog module....${NC}"

--- a/install_pro_testnet.sh
+++ b/install_pro_testnet.sh
@@ -433,7 +433,7 @@ WATCHDOG_INSTALL="1"
 echo -e "${ARROW} ${YELLOW}Downloading...${NC}"
 cd && git clone https://github.com/RunOnFlux/fluxnode-watchdog.git watchdog > /dev/null 2>&1
 echo -e "${ARROW} ${YELLOW}Installing git hooks....${NC}"
-wget https://raw.githubusercontent.com/RunOnFlux/fluxnode-multitool/master/post-merge > /dev/null 2>&1
+wget https://raw.githubusercontent.com/RunOnFlux/fluxnode-multitool/$ROOT_BRANCH/post-merge > /dev/null 2>&1
 mv post-merge /home/$USER/watchdog/.git/hooks/post-merge
 sudo chmod +x /home/$USER/watchdog/.git/hooks/post-merge
 echo -e "${ARROW} ${YELLOW}Installing watchdog module....${NC}"

--- a/multitoolbox.sh
+++ b/multitoolbox.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 
+if ! [[ -z $1 ]]; then
+    if [[ $BREAK_NESTING != '1' ]]; then
+        export ROOT_BRANCH="$1"
+        export BREAK_NESTING='1'
+        bash -i <(curl -s https://raw.githubusercontent.com/RunOnFlux/fluxnode-multitool/$ROOT_BRANCH/multitoolbox.sh) $ROOT_BRANCH
+        exit
+    fi
+else
+    ROOT_BRANCH='master'
+fi
+
 BOOTSTRAP_ZIPFILE='flux_explorer_bootstrap.tar.gz'
 BOOTSTRAP_URL_MONGOD='https://fluxnodeservice.com/mongod_bootstrap.tar.gz'
 BOOTSTRAP_ZIPFILE_MONGOD='mongod_bootstrap.tar.gz'
@@ -1041,7 +1052,7 @@ sudo rm -rf /home/$USER/watchdog  > /dev/null 2>&1
 echo -e "${ARROW} ${CYAN}Downloading...${NC}"
 cd && git clone https://github.com/RunOnFlux/fluxnode-watchdog.git watchdog > /dev/null 2>&1
 echo -e "${ARROW} ${CYAN}Installing git hooks....${NC}"
-wget https://raw.githubusercontent.com/RunOnFlux/fluxnode-multitool/master/post-merge > /dev/null 2>&1
+wget https://raw.githubusercontent.com/RunOnFlux/fluxnode-multitool/$ROOT_BRANCH/post-merge > /dev/null 2>&1
 mv post-merge /home/$USER/watchdog/.git/hooks/post-merge
 sudo chmod +x /home/$USER/watchdog/.git/hooks/post-merge
 echo -e "${ARROW} ${CYAN}Installing watchdog module....${NC}"
@@ -1719,7 +1730,7 @@ if [[ "$USER" == "root" || "$USER" == "ubuntu" || "$USER" == "admin" ]]; then
     exit
 fi
 
-bash -i <(curl -s https://raw.githubusercontent.com/RunOnFlux/fluxnode-multitool/master/nodeanalizerandfixer.sh)
+bash -i <(curl -s https://raw.githubusercontent.com/RunOnFlux/fluxnode-multitool/${ROOT_BRANCH}/nodeanalizerandfixer.sh)
 
 
 }
@@ -1762,7 +1773,7 @@ exit
 fi
 
 
-bash -i <(curl -s https://raw.githubusercontent.com/RunOnFlux/fluxnode-multitool/master/install_pro.sh)
+bash -i <(curl -s https://raw.githubusercontent.com/RunOnFlux/fluxnode-multitool/${ROOT_BRANCH}/install_pro.sh)
 
 
 }
@@ -1801,7 +1812,7 @@ fi
     fi  
     
     sleep 15
-    bash -i <(curl -s https://raw.githubusercontent.com/RunOnFlux/fluxnode-multitool/master/multinode.sh)
+    bash -i <(curl -s https://raw.githubusercontent.com/RunOnFlux/fluxnode-multitool/${ROOT_BRANCH}/multinode.sh)
 
 }
 
@@ -2435,7 +2446,7 @@ sudo apt-get install -y whiptail > /dev/null 2>&1
 fi
 
 if [[ $(cat /etc/bash.bashrc | grep 'multitoolbox' | wc -l) == "0" ]]; then
-echo "alias multitoolbox='bash -i <(curl -s https://raw.githubusercontent.com/RunOnFlux/fluxnode-multitool/master/multitoolbox.sh)'" | sudo tee -a /etc/bash.bashrc
+echo "alias multitoolbox='bash -i <(curl -s https://raw.githubusercontent.com/RunOnFlux/fluxnode-multitool/${ROOT_BRANCH}/multitoolbox.sh)'" | sudo tee -a /etc/bash.bashrc
 source /etc/bash.bashrc
 fi
 
@@ -2451,9 +2462,10 @@ echo -e "${BLUE}"
 figlet -f slant "Multitoolbox"
 echo -e "${YELLOW}================================================================${NC}"
 echo -e "${GREEN}Version: $dversion${NC}"
+echo -e "${GREEN}Branch: $ROOT_BRANCH${NC}"
 echo -e "${GREEN}OS: Ubuntu 16/18/19/20, Debian 9/10 ${NC}"
 echo -e "${GREEN}Created by: X4MiLX from Flux's team${NC}"
-echo -e "${GREEN}Special thanks to dk808, CryptoWrench , jriggs28 && TechDufus${NC}"
+echo -e "${GREEN}Special thanks to dk808, CryptoWrench, jriggs28 && TechDufus${NC}"
 echo -e "${YELLOW}================================================================${NC}"
 echo -e "${CYAN}1  - Install Docker${NC}"
 echo -e "${CYAN}2  - Install FluxNode${NC}"

--- a/multitoolbox_testnet.sh
+++ b/multitoolbox_testnet.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+ROOT_BRANCH="master"
+if ! [ -z "$1" ]; then
+    ROOT_BRANCH="$1"
+fi
+
 BOOTSTRAP_ZIP='https://fluxnodeservice.com/daemon_bootstrap.tar.gz'
 BOOTSTRAP_ZIPFILE='daemon_bootstrap.tar.gz'
 BOOTSTRAP_URL_MONGOD='https://fluxnodeservice.com/mongod_bootstrap.tar.gz'
@@ -701,7 +706,7 @@ sudo rm -rf /home/$USER/watchdog  > /dev/null 2>&1
 echo -e "${ARROW} ${CYAN}Downloading...${NC}"
 cd && git clone https://github.com/RunOnFlux/fluxnode-watchdog.git watchdog > /dev/null 2>&1
 echo -e "${ARROW} ${CYAN}Installing git hooks....${NC}"
-wget https://raw.githubusercontent.com/RunOnFlux/fluxnode-multitool/master/post-merge > /dev/null 2>&1
+wget https://raw.githubusercontent.com/RunOnFlux/fluxnode-multitool/$ROOT_BRANCH/post-merge > /dev/null 2>&1
 mv post-merge /home/$USER/watchdog/.git/hooks/post-merge
 sudo chmod +x /home/$USER/watchdog/.git/hooks/post-merge
 echo -e "${ARROW} ${CYAN}Installing watchdog module....${NC}"
@@ -1354,7 +1359,7 @@ if [[ "$USER" == "root" || "$USER" == "ubuntu" || "$USER" == "admin" ]]; then
     exit
 fi
 
-bash -i <(curl -s https://raw.githubusercontent.com/RunOnFlux/fluxnode-multitool/master/nodeanalizerandfixer.sh)
+bash -i <(curl -s https://raw.githubusercontent.com/RunOnFlux/fluxnode-multitool/${ROOT_BRANCH}/nodeanalizerandfixer.sh)
 
 
 }
@@ -1391,8 +1396,8 @@ exit
 fi
 
 
-# bash -i <(curl -s https://raw.githubusercontent.com/RunOnFlux/fluxnode-multitool/master/install_pro.sh)
-bash -i <(curl -s https://raw.githubusercontent.com/RunOnFlux/fluxnode-multitool/master/install_pro_testnet.sh)
+# bash -i <(curl -s https://raw.githubusercontent.com/RunOnFlux/fluxnode-multitool/${ROOT_BRANCH}/install_pro.sh)
+bash -i <(curl -s https://raw.githubusercontent.com/RunOnFlux/fluxnode-multitool/${ROOT_BRANCH}/install_pro_testnet.sh)
 
 
 }
@@ -1430,7 +1435,7 @@ fi
     fi  
     
     sleep 15
-    bash -i <(curl -s https://raw.githubusercontent.com/RunOnFlux/fluxnode-multitool/master/multinode.sh)
+    bash -i <(curl -s https://raw.githubusercontent.com/RunOnFlux/fluxnode-multitool/${ROOT_BRANCH}/multinode.sh)
 
 }
 
@@ -2095,6 +2100,7 @@ echo -e "${BLUE}"
 figlet -f slant "Multitoolbox TESTNET"
 echo -e "${YELLOW}================================================================${NC}"
 echo -e "${GREEN}Version: $dversion${NC}"
+echo -e "${GREEN}Branch:  ${ROOT_BRANCH}${NC}"
 echo -e "${GREEN}OS: Ubuntu 16/18/19/20, Debian 9/10 ${NC}"
 echo -e "${GREEN}Created by: X4MiLX from Flux's team${NC}"
 echo -e "${GREEN}Special thanks to dk808, CryptoWrench && jriggs28${NC}"


### PR DESCRIPTION
# Summary

This PR will allow `fluxnode-multitool` maintainers to quickly specify a test branch (any branch of multitool that you'd like to test) easily by providing the name of the branch as the first positional argument to `multitoolbox`.

# Justification

Currently, there is no way to test a specific branch with changes to multitoolbox **WITHOUT** pushing new code to your branch to change `all` hardcoded GitHub paths that point to master, to point to your test branch. This makes it VERY difficult to quickly test features / changes that only live in a specific RunOnFlux GitHub branch for multitoolbox.

With this change, Testing will be supported without having to change the GitHub paths to do so.

# Example Use-Case

With this change, the following syntax would be supported for testing a specific branch (like this one)
```bash
bash -i <(curl -s https://raw.githubusercontent.com/RunOnFlux/fluxnode-multitool/master/multitoolbox.sh) branch_specification
## OR ##
multitoolbox branch_specification
```
This would pass the `branch_specification` string to the first positional argument, which overwrites `master` as the default fluxnode-multitool repo branch to reference.

### Quirk workaround

The `if` logic is implemented such that, once we call the correct branch version of multitoolbox, we don't enter an endless loop of recalling the same test branch. the `BREAK_NESTING` variable takes care of this for us. I don't like having nested `if` statements like this, but in this case, it looks to be the 'most correct' guard clause to what I'm trying to do.

This implements Issue #22 