### PR TITLE
Fix node analyzer

### DIFF
--- a/nodeanalizerandfixer.sh
+++ b/nodeanalizerandfixer.sh
@@ -160,7 +160,7 @@ fi
 
 
 if [[ -f /home/$USER/.fluxbenchmark/fluxbench.conf ]]; then
-FluxAPI=$(grep -Po "\\d+" /home/$USER/.fluxbenchmark/fluxbench.conf)
+FluxAPI=$(grep -Po "(?<=fluxport=)\d+" /home/$USER/.fluxbenchmark/fluxbench.conf)
 FLUXOS_CONFIG=$(grep -Po "$FluxAPI" /home/$USER/zelflux/config/userconfig.js)
   if [[ "$FLUXOS_CONFIG" != "" ]]; then
     FluxUI=$(($FluxAPI-1))


### PR DESCRIPTION
Node analyzer and fixer isn't working with the new fluxbench feature wich allows to specify speedtestserverid=XXXXX under .fluxbenchmark/fluxbench.conf.
The new regexp is more restrictive and fix it

![image](https://user-images.githubusercontent.com/66138267/183856206-6c4b07de-d75e-467d-90ed-379b710bcdaf.png)
