### PR TITLE
Remove extra source list entry for focal

### DIFF
--- a/install_pro_testnet.sh
+++ b/install_pro_testnet.sh
@@ -726,7 +726,6 @@ else
       echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/flux-archive-keyring.gpg] https://runonflux.github.io/aptrepo/ focal main" | sudo tee /etc/apt/sources.list.d/flux.list  > /dev/null 2>&1
    else
       echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/flux-archive-keyring.gpg] https://apt.runonflux.io/ focal main" | sudo tee /etc/apt/sources.list.d/flux.list  > /dev/null 2>&1
-      echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/flux-archive-keyring.gpg] https://runonflux.github.io/aptrepo/ focal main" | sudo tee /etc/apt/sources.list.d/flux.list  > /dev/null 2>&1
    fi
    
    

--- a/install_pro_testnet.sh
+++ b/install_pro_testnet.sh
@@ -1402,7 +1402,7 @@ else
    # bootstrap
    # fi
     create_service_scripts
-    create_service
+    create_service "install"
     
  #   if whiptail --yesno "Is the fluxnode being installed on a vps?" 8 60; then   
      # echo -e "${ARROW} ${YELLOW}Cron service for rotate ip skipped...${NC}"


### PR DESCRIPTION
During the Flux Daemon && Benchmark installing step the extra line for the apt source will make installing fluxbench error out. Removing this extra line fixes that.

With the line in place, the error encountered in Ubuntu 20.04 LTS is:

```
▶ Flux Daemon && Benchmark installing...
Reading package lists... Done
Building dependency tree       
Reading state information... Done
The following packages were automatically installed and are no longer required:
  libaio1 libpq5
Use 'sudo apt autoremove' to remove them.
The following NEW packages will be installed:
  flux fluxbench
0 upgraded, 2 newly installed, 0 to remove and 0 not upgraded.
Need to get 1,328 kB/6,394 kB of archives.
After this operation, 0 B of additional disk space will be used.
Get:1 https://runonflux.github.io/aptrepo focal/main amd64 fluxbench amd64 3.4.2 [1,328 kB]
Err:1 https://runonflux.github.io/aptrepo focal/main amd64 fluxbench amd64 3.4.2
  File has unexpected size (132 != 1328112). Mirror sync in progress? [IP: 185.199.111.153 443]
  Hashes of expected file:
   - SHA256:d93e4454e109deee55708215d8080d137a2e8a707164bbcc0da809238dd2c1b0
   - SHA1:cfff03aef3f0c1b53c4c2326fdedc159e00db717 [weak]
   - MD5Sum:0a4b44819111077b3f8c010b440e0935 [weak]
   - Filesize:1328112 [weak]
E: Failed to fetch https://runonflux.github.io/aptrepo/pool/main/f/fluxbench/fluxbench_3.4.2_amd64.deb  File has unexpected size (132 != 1328112). Mirror sync in progress? [IP: 185.199.111.153 443]
   Hashes of expected file:
    - SHA256:d93e4454e109deee55708215d8080d137a2e8a707164bbcc0da809238dd2c1b0
    - SHA1:cfff03aef3f0c1b53c4c2326fdedc159e00db717 [weak]
    - MD5Sum:0a4b44819111077b3f8c010b440e0935 [weak]
    - Filesize:1328112 [weak]
E: Unable to fetch some archives, try running apt-get update or apt-get --fix-missing.
```