### PR TITLE
Exit Function

### DIFF
--- a/flux_common.sh
+++ b/flux_common.sh
@@ -346,7 +346,7 @@ function integration_check() {
 		echo -e "${WORNING} ${CYAN}Flux daemon package corrupted...${NC}"
 		echo -e "${WORNING} ${CYAN}Will exit out so try and run the script again...${NC}"
 		echo -e ""
-		exit
+		toolbox_close
 	fi	
 	
 }
@@ -497,7 +497,7 @@ function get_ip() {
 		if [[ "$WANIP" == "" || "$WANIP" = *htmlhead* ]]; then
 			echo -e "${ARROW} ${CYAN}IP address could not be found, installation stopped .........[${X_MARK}${CYAN}]${NC}"
 			echo
-			exit
+			toolbox_close
 		fi
 		string_limit_check_mark "IP: $WANIP ..........................................." "IP: ${GREEN}$WANIP${CYAN} ..........................................."
 	fi
@@ -622,7 +622,7 @@ function daemon_reconfiguration(){
 		echo -e "${CYAN}Please switch to the user account.${NC}"
 		echo -e "${YELLOW}================================================================${NC}"
 		echo -e "${NC}"
-		exit
+		toolbox_close
 	fi
 	config_veryfity
 	echo -e ""
@@ -650,7 +650,7 @@ function daemon_reconfiguration(){
 	if [[ "$skip_change" == "0" ]]; then
 		echo -e "${ARROW} ${YELLOW}All fields are empty changes skipped...${NC}"
 		echo
-		exit
+		toolbox_close
 	fi
 	echo -e "${ARROW} ${CYAN}Stopping Flux daemon service...${NC}"
 	sudo systemctl stop $COIN_NAME  > /dev/null 2>&1 && sleep 2
@@ -752,12 +752,12 @@ function fluxos_reconfiguration {
 		echo -e "${CYAN}Please switch to the user account.${NC}"
 		echo -e "${YELLOW}================================================================${NC}"
 		echo -e "${NC}"
-		exit
+		toolbox_close
  fi
  if ! [[ -f /home/$USER/zelflux/config/userconfig.js ]]; then
 	 echo -e "${WORNING} ${CYAN}FluxOS userconfig.js not exist, operation aborted${NC}"
 	 echo -e ""
-	 exit
+	 toolbox_close
  fi
  CHOICE=$(
  whiptail --title "FluxOS Configuration" --menu "Make your choice" 15 40 6 \
@@ -1089,13 +1089,13 @@ function start_install() {
 		else
 			string_limit_x_mark "JQ was not installed................................."
 			echo
-			exit
+			toolbox_close
 		fi
 	fi
 	if [ "$USER" = "root" ]; then
 		echo -e "${CYAN}You are currently logged in as ${GREEN}root${CYAN}, please switch to the username you just created.${NC}"
 		sleep 4
-		exit
+		toolbox_close
 	fi
 	start_dir=$(pwd)
 	correct_dir="/home/$USER"
@@ -1358,7 +1358,7 @@ function create_service() {
 			echo -e "${CYAN}Please switch to the user account.${NC}"
 			echo -e "${YELLOW}================================================================${NC}"
 			echo -e "${NC}"
-			exit
+			toolbox_close
 		fi 
 		echo -e ""
 		echo -e "${ARROW} ${CYAN}Cleaning...${NC}" && sleep 1
@@ -1585,7 +1585,7 @@ function selfhosting_creator(){
 		echo -e "${CYAN}Please switch to the user account.${NC}"
 		echo -e "${YELLOW}================================================================${NC}"
 		echo -e "${NC}"
-		exit
+		toolbox_close
 	fi
 
 	CHOICE=$(
@@ -1631,7 +1631,7 @@ function selfhosting_creator(){
 				else
 					echo -e "${ARROW} ${CYAN}Operation aborted, device interface was not selected...${NC}"
 					echo -e ""
-					exit
+					toolbox_close
 				fi
 				selfhosting
 			;;
@@ -1749,7 +1749,7 @@ function multinode(){
 		echo -e "${CYAN}Please switch to the user account.${NC}"
 		echo -e "${YELLOW}================================================================${NC}"
 		echo -e "${NC}"
-		exit
+		toolbox_close
 	fi
 	echo -e ""
 	echo -e "${ARROW}  ${CYAN}OPTION ALLOWS YOU: ${NC}"
@@ -1766,7 +1766,7 @@ function multinode(){
 		echo -e "${WORNING} ${CYAN}First install FluxNode...${NC}"
 		echo -e "${WORNING} ${CYAN}Operation stopped...${NC}"
 		echo -e ""
-		exit
+		toolbox_close
 	fi  
 	sleep 8
 	bash -i <(curl -s https://raw.githubusercontent.com/RunOnFlux/fluxnode-multitool/${ROOT_BRANCH}/multinode.sh)
@@ -1779,7 +1779,7 @@ function install_watchtower(){
 		echo -e "${CYAN}Please switch to the user account.${NC}"
 		echo -e "${YELLOW}================================================================${NC}"
 		echo -e "${NC}"
-		exit
+		toolbox_close
 	fi 
 	echo -e ""
 	echo -e "${ARROW} ${CYAN}Checking if flux_watchtower is installed....${NC}"
@@ -1816,7 +1816,19 @@ function analyzer_and_fixer(){
 		echo -e "${CYAN}Please switch to the user account.${NC}"
 		echo -e "${YELLOW}================================================================${NC}"
 		echo -e "${NC}"
-		exit
+		toolbox_close
 	fi
 	bash -i <(curl -s https://raw.githubusercontent.com/RunOnFlux/fluxnode-multitool/${ROOT_BRANCH}/nodeanalizerandfixer.sh)
+}
+function toolbox_close(){
+	echo -e ""
+	echo -e " Cleaning branch variable..."
+	echo -e ""
+	unset ROOT_BRANCH
+	unset BRANCH_ALREADY_REFERENCE
+	echo -e ""
+	echo -e " Enabling history"
+	echo -e ""
+	set -o history
+	exit
 }

--- a/install_pro.sh
+++ b/install_pro.sh
@@ -521,7 +521,7 @@ function ssh_port() {
 		else
 			echo -e "${ARROW} ${CYAN}SSH port must be integer................[${X_MARK}${CYAN}]${NC}}"
 			echo
-			exit
+			toolbox_close
 		fi	   
 	fi
 }
@@ -614,7 +614,7 @@ function install_daemon() {
 			echo -e "${WORNING} ${RED}Importing public GPG Key failed...${NC}"
 			echo -e "${WORNING} ${CYAN}Installation stopped...${NC}"
 			echo -e ""
-			exit
+			toolbox_close
 		fi
 	fi
 }
@@ -681,7 +681,7 @@ function start_daemon() {
 				echo -e "${WORNING} ${CYAN}Last error from ~/$CONFIG_DIR/debug.log: ${NC}"
 				echo -e "${WORNING} ${CYAN}$error_line${NC}"
 				echo -e ""
-				exit
+				toolbox_close
 			fi  	       
 		fi
 		if whiptail --yesno "Something is not right the daemon did not start or still loading....\nWould you like continue the installation (make sure that flux daemon working) Y/N?" 8 90; then
@@ -690,7 +690,7 @@ function start_daemon() {
 		else
 			echo -e "${WORNING} ${RED}Installation stopped by user...${NC}"
 			echo -n ""
-			exit
+			toolbox_close
 		fi	
 	fi
 }
@@ -716,7 +716,7 @@ function install_process() {
 			echo -e "${WORNING} ${RED}OS type not supported..${NC}"
 			echo -e "${WORNING} ${CYAN}Installation stopped...${NC}"
 			echo
-			exit    
+			toolbox_close    
 		fi
 	else
 		curl -fsSL https://www.mongodb.org/static/pgp/server-6.0.asc | gpg --dearmor | sudo tee /usr/share/keyrings/mongodb-archive-keyring.gpg > /dev/null 2>&1
@@ -728,7 +728,7 @@ function install_process() {
 			echo -e "${WORNING} ${RED}OS type not supported..${NC}"
 			echo -e "${WORNING} ${CYAN}Installation stopped...${NC}"
 			echo
-			exit    
+			toolbox_close    
 		fi
 	fi
 	

--- a/install_pro_testnet.sh
+++ b/install_pro_testnet.sh
@@ -602,7 +602,7 @@ function ssh_port() {
 	else
 	 echo -e "${ARROW} ${CYAN}SSH port must be integer................[${X_MARK}${CYAN}]${NC}}"
 	 echo
-	 exit
+	 toolbox_close
 	fi	   
     fi
 }
@@ -623,11 +623,9 @@ function ip_confirm() {
         
     if [[ "$WANIP" == "" ]]; then
       	echo -e "${ARROW} ${CYAN}IP address could not be found, installation stopped .........[${X_MARK}${CYAN}]${NC}"
-	echo
-	exit
+				echo
+				toolbox_close
     fi
-	 
-	 
    string_limit_check_mark "Detected IP: $WANIP ................................." "Detected IP: ${GREEN}$WANIP${CYAN} ................................."
     
 }
@@ -730,7 +728,7 @@ else
      echo -e "${WORNING} ${RED}Importing public GPG Key failed...${NC}"
      echo -e "${WORNING} ${CYAN}Installation stopped...${NC}"
      echo
-     exit
+     toolbox_close
    fi 
 fi
 sudo rm -rf  /tmp/*lux* 2>&1 && sleep 2
@@ -1025,7 +1023,7 @@ function start_daemon() {
 	       echo -e "${WORNING} ${CYAN}Last error from ~/$CONFIG_DIR/debug.log: ${NC}"
 	       echo -e "${WORNING} ${CYAN}$error_line${NC}"
 	       echo
-	       exit
+	       toolbox_close
 	     fi  	       
         fi
 	
@@ -1039,7 +1037,7 @@ function start_daemon() {
 	
 	  echo -e "${WORNING} ${RED}Installation stopped by user...${NC}"
 	  echo -n ""
-	  exit
+	  toolbox_close
 
 	fi
 
@@ -1087,7 +1085,7 @@ function install_process() {
       echo -e "${WORNING} ${RED}OS type not supported..${NC}"
       echo -e "${WORNING} ${CYAN}Installation stopped...${NC}"
       echo
-      exit    
+      toolbox_close    
 
     fi
     

--- a/multinode.sh
+++ b/multinode.sh
@@ -5,7 +5,7 @@ function upnp_disable() {
  if [[ ! -f /home/$USER/zelflux/config/userconfig.js ]]; then
 		echo -e "${WORNING} ${CYAN}Missing FluxOS configuration file - install/re-install Flux Node...${NC}" 
 		echo -e ""
-		exit
+		toolbox_close
  fi
  if [[ -f /home/$USER/.fluxbenchmark/fluxbench.conf ]]; then
  echo -e ""
@@ -14,7 +14,7 @@ function upnp_disable() {
  else
 	 echo -e "${ARROW} ${CYAN}UPnP Mode is already disabled...${NC}"
 	 echo -e ""
-	 exit
+	 toolbox_close
  fi
  if [[ $(cat /home/$USER/zelflux/config/userconfig.js | grep 'apiport' | wc -l) == "1" ]]; then
 	cat /home/$USER/zelflux/config/userconfig.js | sed '/apiport/d' | sudo tee "/home/$USER/zelflux/config/userconfig.js" > /dev/null

--- a/multitoolbox.sh
+++ b/multitoolbox.sh
@@ -1,15 +1,7 @@
 #!/bin/bash
 
-trap ctrl_c INT
-
-function ctrl_c() {
-	echo -e ""
-	echo -e " Cleaning branch variable..."
-	echo -e ""
-	unset ROOT_BRANCH
-	unset BRANCH_ALREADY_REFERENCE
-	exit
-}
+#disable terminal history while inside of app
+set +o history
 
 if ! [[ -z $1 ]]; then
 	if [[ $BRANCH_ALREADY_REFERENCED != '1' ]]; then
@@ -18,12 +10,18 @@ if ! [[ -z $1 ]]; then
 	bash -i <(curl -s https://raw.githubusercontent.com/RunOnFlux/fluxnode-multitool/$ROOT_BRANCH/multitoolbox.sh) $ROOT_BRANCH
 	unset ROOT_BRANCH
 	unset BRANCH_ALREADY_REFERENCED
-	exit
+	toolbox_close
 	fi
 else
 	export ROOT_BRANCH='master'
 fi
 source /dev/stdin <<< "$(curl -s https://raw.githubusercontent.com/RunOnFlux/fluxnode-multitool/$ROOT_BRANCH/flux_common.sh)"
+
+trap ctrl_c INT
+function ctrl_c() {
+	toolbox_close
+}
+
 if [[ -d /home/$USER/.zelcash ]]; then
 	CONFIG_DIR='.zelcash'
 	CONFIG_FILE='zelcash.conf'
@@ -50,7 +48,7 @@ function config_veryfity(){
 			echo -e "${WORNING} ${CYAN}Insightexplorer disabled.............[${X_MARK}${CYAN}]${NC}"
 			echo -e "${WORNING} ${CYAN}Use option 2 for node re-install${NC}"
 			echo -e ""
-			exit
+			toolbox_close
 		fi
 	fi
 }
@@ -114,7 +112,7 @@ function install_flux() {
 		echo -e "${CYAN}Please switch to the user account.${NC}"
 		echo -e "${YELLOW}================================================================${NC}"
 		echo -e "${NC}"
-		exit
+		toolbox_close
 	fi
 
 	if pm2 -v > /dev/null 2>&1; then
@@ -183,13 +181,13 @@ function install_flux() {
 		else
 			string_limit_x_mark "FluxOS was not downloaded, run script again..........................................."
 			echo
-			exit
+			toolbox_close
 		fi
 		string_limit_check_mark "FluxOS v$current_ver downloaded..........................................." "FluxOS ${GREEN}v$current_ver${CYAN} downloaded..........................................."
 	else
 		string_limit_x_mark "FluxOS was not downloaded, run script again..........................................."
 		echo
-		exit
+		toolbox_close
 	fi
 
 	if [[ "$zelflux_setting_import" == "0" ]]; then
@@ -226,7 +224,7 @@ function install_flux() {
 	else
 		string_limit_x_mark "FluxOS installation failed, missing config file..........................................."
 		echo
-		exit
+		toolbox_close
 	fi
 
 	if pm2 -v > /dev/null 2>&1; then 
@@ -256,7 +254,7 @@ function create_config() {
 		echo -e "${CYAN}Please switch to the user account.${NC}"
 		echo -e "${YELLOW}================================================================${NC}"
 		echo -e "${NC}"
-		exit
+		toolbox_close
 	fi
 	echo -e "${GREEN}Module: Create FluxNode installation config file${NC}"
 	echo -e "${YELLOW}================================================================${NC}"
@@ -273,7 +271,7 @@ function create_config() {
 			#echo -e "${ARROW} ${CYAN}Nodejs was not installed${NC}"
 			string_limit_x_mark "JQ was not installed................................."
 			echo
-			exit
+			toolbox_close
 		fi
 	fi
 	skip_zelcash_config='0'
@@ -516,14 +514,14 @@ function install_watchdog() {
 		echo -e "${CYAN}Please switch to the user account.${NC}"
 		echo -e "${YELLOW}================================================================${NC}"
 		echo -e "${NC}"
-		exit
+		toolbox_close
 	fi
 	echo -e "${GREEN}Module: Install watchdog for FluxNode${NC}"
 	echo -e "${YELLOW}================================================================${NC}"
 	if ! pm2 -v > /dev/null 2>&1; then
 		pm2_install
 		if [[ "$PM2_INSTALL" == "0" ]]; then
-			exit
+			toolbox_close
 		fi
 		echo -e ""
 	fi
@@ -708,7 +706,7 @@ function flux_daemon_bootstrap() {
 		echo -e "${CYAN}Please switch to the user account.${NC}"
 		echo -e "${YELLOW}================================================================${NC}"
 		echo -e "${NC}"
-		exit
+		toolbox_close
 	fi
 	cd
 	echo -e "${NC}"
@@ -723,25 +721,25 @@ function install_node(){
 		echo -e "${CYAN}Please switch to the user account.${NC}"
 		echo -e "${YELLOW}================================================================${NC}"
 		echo -e "${NC}"
-		exit
+		toolbox_close
 	fi
 	if [[ $(lsb_release -d) != *Debian* && $(lsb_release -d) != *Ubuntu* ]]; then
 		echo -e "${WORNING} ${CYAN}ERROR: ${RED}OS version not supported${NC}"
 		echo -e "${WORNING} ${CYAN}Installation stopped...${NC}"
 		echo
-		exit
+		toolbox_close
 	fi
 	if [[ $(lsb_release -cs) == "jammy" ]]; then
 		echo -e "${WORNING} ${CYAN}ERROR: ${RED}OS version not supported${NC}"
 		echo -e "${WORNING} ${CYAN}Installation stopped...${NC}"
 		echo
-		exit
+		toolbox_close
 	fi
 	if sudo docker run hello-world > /dev/null 2>&1; then
 		echo -e ""
 	else
 		echo -e "${WORNING}${CYAN}Docker is not working correct or is not installed.${NC}"
-		exit
+		toolbox_close
 	fi
 	bash -i <(curl -s https://raw.githubusercontent.com/RunOnFlux/fluxnode-multitool/${ROOT_BRANCH}/install_pro.sh)
 }
@@ -753,19 +751,19 @@ function install_docker(){
 		echo -e "${CYAN}Please switch to the root account use command 'sudo su -'.${NC}"
 		echo -e "${YELLOW}================================================================${NC}"
 		echo -e "${NC}"
-		exit
+		toolbox_close
 	fi
 	if [[ $(lsb_release -d) != *Debian* && $(lsb_release -d) != *Ubuntu* ]]; then
 		echo -e "${WORNING} ${CYAN}ERROR: ${RED}OS version not supported${NC}"
 		echo -e "${WORNING} ${CYAN}Installation stopped...${NC}"
 		echo
-		exit
+		toolbox_close
 	fi
 	if [[ $(lsb_release -cs) == "jammy" ]]; then
 		echo -e "${WORNING} ${CYAN}ERROR: ${RED}OS version not supported${NC}"
 		echo -e "${WORNING} ${CYAN}Installation stopped...${NC}"
 		echo
-		exit
+		toolbox_close
 	fi
 	if [[ -z "$usernew" ]]; then
 		usernew="$(whiptail --title "MULTITOOLBOX $dversion" --inputbox "Enter your username" 8 72 3>&1 1>&2 2>&3)"
@@ -849,7 +847,7 @@ function install_watchtower(){
 		echo -e "${CYAN}Please switch to the user account.${NC}"
 		echo -e "${YELLOW}================================================================${NC}"
 		echo -e "${NC}"
-		exit
+		toolbox_close
 	fi 
 	echo -e ""
 	echo -e "${ARROW} ${CYAN}Checking if flux_watchtower is installed....${NC}"
@@ -887,7 +885,7 @@ function mongod_db_fix() {
 		echo -e "${CYAN}Please switch to the user account.${NC}"
 		echo -e "${YELLOW}================================================================${NC}"
 		echo -e "${NC}"
-		exit
+		toolbox_close
 	fi 
 
 
@@ -1141,7 +1139,7 @@ case "$REPLY" in
 		echo -e "${CYAN}Please switch to the user account.${NC}"
 		echo -e "${YELLOW}================================================================${NC}"
 		echo -e "${NC}"
-		exit
+		toolbox_close
 	fi
 	node_reconfiguration
 	echo -e ""

--- a/multitoolbox_testnet.sh
+++ b/multitoolbox_testnet.sh
@@ -128,7 +128,7 @@ if [[ "$USER" == "root" || "$USER" == "ubuntu" ]]; then
     echo -e "${CYAN}Please switch to the user account.${NC}"
     echo -e "${YELLOW}================================================================${NC}"
     echo -e "${NC}"
-    exit
+    toolbox_close
 fi
 
  if pm2 -v > /dev/null 2>&1; then
@@ -218,14 +218,14 @@ if [[ -f /home/$USER/$FLUX_DIR/package.json ]]; then
 else
   string_limit_x_mark "Flux was not downloaded, run script again..........................................."
   echo
-  exit
+  toolbox_close
 fi
 
 string_limit_check_mark "Flux v$current_ver downloaded..........................................." "Flux ${GREEN}v$current_ver${CYAN} downloaded..........................................."
 else
 string_limit_x_mark "Flux was not downloaded, run script again..........................................."
 echo
-exit
+toolbox_close
 fi
 
 
@@ -296,7 +296,7 @@ string_limit_check_mark "Flux configuration successfull.........................
 else
 string_limit_x_mark "Flux installation failed, missing config file..........................................."
 echo
-exit
+toolbox_close
 fi
 
  if pm2 -v > /dev/null 2>&1; then 
@@ -331,7 +331,7 @@ if [[ "$USER" == "root" || "$USER" == "ubuntu" || "$USER" == "admin" ]]; then
     echo -e "${CYAN}Please switch to the user account.${NC}"
     echo -e "${YELLOW}================================================================${NC}"
     echo -e "${NC}"
-    exit
+    toolbox_close
 fi
 
 echo -e "${GREEN}Module: Create FluxNode installation config file${NC}"
@@ -353,7 +353,7 @@ sudo apt  install jq -y > /dev/null 2>&1
     #echo -e "${ARROW} ${CYAN}Nodejs was not installed${NC}"
     string_limit_x_mark "JQ was not installed................................."
     echo
-    exit
+    toolbox_close
   fi
 fi
 
@@ -421,7 +421,7 @@ sleep 1
 else
 echo -e "${ARROW} ${CYAN}SSH port must be integer.................................[${X_MARK}${CYAN}]${NC}"
 echo
-exit
+toolbox_close
 fi
 
 
@@ -515,7 +515,7 @@ if [[ "$USER" == "root" || "$USER" == "ubuntu" || "$USER" == "admin" ]]; then
     echo -e "${CYAN}Please switch to the user account.${NC}"
     echo -e "${YELLOW}================================================================${NC}"
     echo -e "${NC}"
-    exit
+    toolbox_close
 fi
 
 echo -e "${GREEN}Module: Install watchdog for FluxNode${NC}"
@@ -525,7 +525,7 @@ if ! pm2 -v > /dev/null 2>&1
 then
 pm2_install
  if [[ "$PM2_INSTALL" == "0" ]]; then
-   exit
+   toolbox_close
  fi
 echo -e ""
 fi
@@ -777,7 +777,7 @@ function flux_daemon_bootstrap() {
         echo -e "${CYAN}Please switch to the user account.${NC}"
         echo -e "${YELLOW}================================================================${NC}"
         echo -e "${NC}"
-        exit
+        toolbox_close
     fi
 
     cd
@@ -904,7 +904,7 @@ if [[ "$USER" == "root" || "$USER" == "ubuntu" || "$USER" == "admin" ]]; then
     echo -e "${CYAN}Please switch to the user account.${NC}"
     echo -e "${YELLOW}================================================================${NC}"
     echo -e "${NC}"
-    exit
+    toolbox_close
 fi
 
 if [[ $(lsb_release -d) != *Debian* && $(lsb_release -d) != *Ubuntu* ]]; then
@@ -912,7 +912,7 @@ if [[ $(lsb_release -d) != *Debian* && $(lsb_release -d) != *Ubuntu* ]]; then
    echo -e "${WORNING} ${CYAN}ERROR: ${RED}OS version not supported${NC}"
    echo -e "${WORNING} ${CYAN}Installation stopped...${NC}"
    echo
-   exit
+   toolbox_close
 fi
 
 
@@ -921,7 +921,7 @@ then
 echo -e ""
 else
 echo -e "${WORNING}${CYAN}Docker is not working correct or is not installed.${NC}"
-exit
+toolbox_close
 fi
 
 
@@ -942,7 +942,7 @@ if [[ "$USER" != "root" ]]; then
     echo -e "${CYAN}Please switch to the root account use command 'su -'.${NC}"
     echo -e "${YELLOW}================================================================${NC}"
     echo -e "${NC}"
-    exit
+    toolbox_close
 fi
 
 
@@ -952,7 +952,7 @@ if [[ $(lsb_release -d) != *Debian* && $(lsb_release -d) != *Ubuntu* ]]; then
     echo -e "${WORNING} ${CYAN}ERROR: ${RED}OS version not supported${NC}"
     echo -e "${WORNING} ${CYAN}Installation stopped...${NC}"
     echo
-    exit
+    toolbox_close
 
 fi
 
@@ -1054,7 +1054,7 @@ if [[ "$USER" == "root" || "$USER" == "ubuntu" || "$USER" == "admin" ]]; then
     echo -e "${CYAN}Please switch to the user account.${NC}"
     echo -e "${YELLOW}================================================================${NC}"
     echo -e "${NC}"
-    exit
+    toolbox_close
 fi
 
 echo
@@ -1094,7 +1094,7 @@ fi
 if [[ "$skip_change" == "0" ]]; then
 echo -e "${ARROW} ${YELLOW}All fields are empty changes skipped...${NC}"
 echo
-exit
+toolbox_close
 fi
 
 echo -e "${ARROW} ${CYAN}Stopping Flux daemon service...${NC}"
@@ -1176,7 +1176,7 @@ echo -e "" && echo -e ""
     echo -e "${CYAN}Please switch to the user account.${NC}"
     echo -e "${YELLOW}================================================================${NC}"
     echo -e "${NC}"
-    exit
+    toolbox_close
   fi 
  
 
@@ -1234,7 +1234,7 @@ fi
     echo -e "${CYAN}Please switch to the user account.${NC}"
     echo -e "${YELLOW}================================================================${NC}"
     echo -e "${NC}"
-    exit
+    toolbox_close
   fi 
  
   echo -e ""

--- a/nodeanalizerandfixer.sh
+++ b/nodeanalizerandfixer.sh
@@ -207,7 +207,7 @@ if [[ "$USER" == "root" || "$USER" == "ubuntu" || "$USER" == "admin" ]]; then
 	echo -e "${CYAN}Please switch to the user accont.${NC}"
 	echo -e "${YELLOW}================================================================${NC}"
 	echo -e "${NC}"
-	exit
+	toolbox_close
 fi
 sleep 1
 if ! bc -v > /dev/null 2>&1 ; then


### PR DESCRIPTION
Disable bash histroy on script entry
Re-enable on exit or ctrl-c

Will need some review as there were a bunch of exit functions to replace - but this will keep the toolbox from filling up the terminal history.