### PR TITLE
Trap exit

### DIFF
--- a/flux_common.sh
+++ b/flux_common.sh
@@ -1,4 +1,19 @@
 #!/bin/bash
+#trap EXIT call and unset vars and enable history
+trap toolbox_close EXIT
+function toolbox_close(){
+	echo -e ""
+	echo -e " Cleaning branch variable..."
+	echo -e ""
+	unset ROOT_BRANCH
+	unset BRANCH_ALREADY_REFERENCE
+	echo -e ""
+	echo -e " Enabling history"
+	echo -e ""
+	set -o history
+}
+#disable bash history
+set +o history
 # Collection of common vars and functions used throughout multitoolbox.
 #color codes
 RED='\033[1;31m'

--- a/flux_common.sh
+++ b/flux_common.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+#disable bash history
+set +o history
 #trap EXIT call and unset vars and enable history
 trap toolbox_close EXIT
 function toolbox_close(){
@@ -12,8 +14,11 @@ function toolbox_close(){
 	echo -e ""
 	set -o history
 }
-#disable bash history
-set +o history
+trap ctrl_c INT
+# exit on ctl_c and call toolbox close from EXIT trap
+function ctrl_c() {
+	exit
+}
 # Collection of common vars and functions used throughout multitoolbox.
 #color codes
 RED='\033[1;31m'

--- a/multitoolbox.sh
+++ b/multitoolbox.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+#disable bash history
+set +o history
 
 trap ctrl_c INT
 # could possibly remove the cleaning branch and put it all in exit function since it should get called
@@ -18,6 +20,7 @@ if ! [[ -z $1 ]]; then
 	bash -i <(curl -s https://raw.githubusercontent.com/RunOnFlux/fluxnode-multitool/$ROOT_BRANCH/multitoolbox.sh) $ROOT_BRANCH
 	unset ROOT_BRANCH
 	unset BRANCH_ALREADY_REFERENCED
+	set -o history
 	exit
 	fi
 else

--- a/multitoolbox.sh
+++ b/multitoolbox.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 trap ctrl_c INT
+trap toolbox_close EXIT
 
+# could possibly remove the cleaning branch and put it all in exit function since it should get called
 function ctrl_c() {
 	echo -e ""
 	echo -e " Cleaning branch variable..."
@@ -10,6 +12,21 @@ function ctrl_c() {
 	unset BRANCH_ALREADY_REFERENCE
 	exit
 }
+
+function toolbox_close(){
+	echo -e ""
+	echo -e " Cleaning branch variable..."
+	echo -e ""
+	unset ROOT_BRANCH
+	unset BRANCH_ALREADY_REFERENCE
+	echo -e ""
+	echo -e " Enabling history"
+	echo -e ""
+	set -o history
+}
+
+#disable bash history
+set +o history
 
 if ! [[ -z $1 ]]; then
 	if [[ $BRANCH_ALREADY_REFERENCED != '1' ]]; then

--- a/multitoolbox.sh
+++ b/multitoolbox.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
 trap ctrl_c INT
-trap toolbox_close EXIT
-
 # could possibly remove the cleaning branch and put it all in exit function since it should get called
 function ctrl_c() {
 	echo -e ""
@@ -12,21 +10,6 @@ function ctrl_c() {
 	unset BRANCH_ALREADY_REFERENCE
 	exit
 }
-
-function toolbox_close(){
-	echo -e ""
-	echo -e " Cleaning branch variable..."
-	echo -e ""
-	unset ROOT_BRANCH
-	unset BRANCH_ALREADY_REFERENCE
-	echo -e ""
-	echo -e " Enabling history"
-	echo -e ""
-	set -o history
-}
-
-#disable bash history
-set +o history
 
 if ! [[ -z $1 ]]; then
 	if [[ $BRANCH_ALREADY_REFERENCED != '1' ]]; then

--- a/multitoolbox.sh
+++ b/multitoolbox.sh
@@ -1012,6 +1012,8 @@ fi
 if [[ $(cat /etc/bash.bashrc | grep 'multitoolbox' | wc -l) == "0" ]]; then
 	echo "alias multitoolbox='bash -i <(curl -s https://raw.githubusercontent.com/RunOnFlux/fluxnode-multitool/master/multitoolbox.sh)'" | sudo tee -a /etc/bash.bashrc
 	echo "alias multitoolbox_testnet='bash -i <(curl -s https://raw.githubusercontent.com/RunOnFlux/fluxnode-multitool/master/multitoolbox_testnet.sh)'" | sudo tee -a /etc/bash.bashrc
+	alias multitoolbox='bash -i <(curl -s https://raw.githubusercontent.com/RunOnFlux/fluxnode-multitool/master/multitoolbox.sh)'
+	alias multitoolbox_testnet='bash -i <(curl -s https://raw.githubusercontent.com/RunOnFlux/fluxnode-multitool/master/multitoolbox_testnet.sh)'
 	source /etc/bash.bashrc
 fi
 

--- a/multitoolbox.sh
+++ b/multitoolbox.sh
@@ -2,17 +2,6 @@
 #disable bash history
 set +o history
 
-trap ctrl_c INT
-# could possibly remove the cleaning branch and put it all in exit function since it should get called
-function ctrl_c() {
-	echo -e ""
-	echo -e " Cleaning branch variable..."
-	echo -e ""
-	unset ROOT_BRANCH
-	unset BRANCH_ALREADY_REFERENCE
-	exit
-}
-
 if ! [[ -z $1 ]]; then
 	if [[ $BRANCH_ALREADY_REFERENCED != '1' ]]; then
 	export ROOT_BRANCH="$1"


### PR DESCRIPTION
Simplified exit trap function and bash history disable while inside script

Disable bash histroy on script entry
Re-enable on exit or ctrl-c int

Will need some review to see if ctrl_c trap can just call exit to clean branch variable