### PR TITLE
Testnet docker automation

### DIFF
--- a/multitoolbox_testnet.sh
+++ b/multitoolbox_testnet.sh
@@ -36,7 +36,7 @@ FLUX_DIR='zelflux'
 FLUX_APPS_DIR='ZelApps'
 COIN_NAME='zelcash'
 
-dversion="v6.0"
+dversion="v6.1"
 
 PM2_INSTALL="0"
 zelflux_setting_import="0"

--- a/multitoolbox_testnet.sh
+++ b/multitoolbox_testnet.sh
@@ -956,8 +956,12 @@ if [[ $(lsb_release -d) != *Debian* && $(lsb_release -d) != *Ubuntu* ]]; then
 
 fi
 
-usernew="$(whiptail --title "MULTITOOLBOX $dversion" --inputbox "Enter your username" 8 72 3>&1 1>&2 2>&3)"
-usernew=$(awk '{print tolower($0)}' <<< "$usernew")
+if [[ -z "$usernew" ]]; then
+    usernew="$(whiptail --title "MULTITOOLBOX $dversion" --inputbox "Enter your username" 8 72 3>&1 1>&2 2>&3)"
+    usernew=$(awk '{print tolower($0)}' <<< "$usernew")
+else
+    echo -e "${PIN}${CYAN} Import docker user '$usernew' from environment variable............[${CHECK_MARK}${CYAN}]${NC}" 
+fi
 echo -e "${ARROW} ${CYAN}New User: ${GREEN}${usernew}${NC}"
 adduser --gecos "" "$usernew" 
 usermod -aG sudo "$usernew" > /dev/null 2>&1  


### PR DESCRIPTION
This provides the exact same functionality that the current mainnet `option 1` gives you.

![image](https://user-images.githubusercontent.com/46715299/201827152-3aec7de7-f726-4ffd-8ef7-5b1efe20c916.png)

See https://github.com/RunOnFlux/fluxnode-multitool/pull/15 for reference..