### PR TITLE
UPnP Enable before starting Flux during option 2

### DIFF
--- a/flux_common.sh
+++ b/flux_common.sh
@@ -2173,20 +2173,25 @@ function upnp_enable() {
 			sudo ufw allow from $router_ip to any proto udp > /dev/null 2>&1
 		fi
 	fi
-	sudo systemctl restart zelcash  > /dev/null 2>&1
-	pm2 restart flux  > /dev/null 2>&1
-	sleep 150
-	echo -e "${ARROW}${CYAN} Checking FluxOS logs... ${NC}"
-	error_check=$(tail -n10 /home/$USER/.pm2/logs/flux-out.log | grep "UPnP failed")
-	if [[ "$error_check" == "" ]]; then
-		echo -e ""
-		LOCAL_IP=$(ip -o route get to 8.8.8.8 | sed -n 's/.*src \([0-9.]\+\).*/\1/p')
-		ZELFRONTPORT=$(($FLUX_PORT-1))
-		echo -e "${PIN} ${CYAN}To access your FluxOS use this url: ${SEA}http://${LOCAL_IP}:$ZELFRONTPORT${NC}"
-		echo -e ""
+	if [[ "$1" != "install" ]]; then
+		sudo systemctl restart zelcash  > /dev/null 2>&1
+		pm2 restart flux  > /dev/null 2>&1
+		sleep 150
+		echo -e "${ARROW}${CYAN} Checking FluxOS logs... ${NC}"
+		error_check=$(tail -n10 /home/$USER/.pm2/logs/flux-out.log | grep "UPnP failed")
+		if [[ "$error_check" == "" ]]; then
+			echo -e ""
+			LOCAL_IP=$(ip -o route get to 8.8.8.8 | sed -n 's/.*src \([0-9.]\+\).*/\1/p')
+			ZELFRONTPORT=$(($FLUX_PORT-1))
+			echo -e "${PIN} ${CYAN}To access your FluxOS use this url: ${SEA}http://${LOCAL_IP}:$ZELFRONTPORT${NC}"
+			echo -e ""
+		else
+			echo -e "${WORNING} ${RED}Problem with UPnP detected, FluxOS Shutting down...${NC}"
+			echo -e ""
+		fi
 	else
-		echo -e "${WORNING} ${RED}Problem with UPnP detected, FluxOS Shutting down...${NC}"
-		echo -e ""
+			LOCAL_IP=$(ip -o route get to 8.8.8.8 | sed -n 's/.*src \([0-9.]\+\).*/\1/p')
+			ZELFRONTPORT=$(($FLUX_PORT-1))
 	fi
 }
 #### TESTNET

--- a/install_pro.sh
+++ b/install_pro.sh
@@ -675,7 +675,6 @@ if [[ "$thunder" == "1" ]]; then
 	echo -e "${ARROW} ${YELLOW}Thunder Mode configuration...${NC}"
 	thunder_mode "install"
 fi
-finalizing
 if [[ "$gateway_ip" != "" && "$upnp_port" != "" ]] && [[ "$upnp_port" != "null" ]] ; then
 	upnp_enable "install"
 fi

--- a/install_pro.sh
+++ b/install_pro.sh
@@ -821,8 +821,8 @@ log_rotate "Docker" "docker_debug_log" "/var/lib/docker/containers/*/*.log" "dai
 basic_security
 status_loop
 install_watchdog
-finalizing
 if [[ "$gateway_ip" != "" && "$upnp_port" != "" ]] && [[ "$upnp_port" != "null" ]] ; then
-	upnp_enable
+	upnp_enable "install"
 fi
+finalizing
 display_banner


### PR DESCRIPTION
- Adding install argument to enable_upnp function
- Move upnp enable above finalizing function in installpro

Currently does not catch upnp errors because FluxOS isn't running or started yet, so skipping upnp error check during installation.