### PR TITLE
More detailed error message for os_check

### DIFF
--- a/flux_common.sh
+++ b/flux_common.sh
@@ -90,7 +90,7 @@ function fluxos_conf_create(){
 	  zelid: '${ZELID}',
 	  kadena: '${KDA_A}',
 	  development: false,
-          decryptionkey: '',
+	  decryptionkey: '',
 	  testnet: $testnet
 	  }
 	}
@@ -882,11 +882,14 @@ function os_check(){
   for (( p=0; p<${LIST_LENGTH}; p++ ));
   do
     if [[ $(lsb_release -cs) == ${BLACK_LIST[$p]} ]]; then 
-        echo -e "${WORNING} ${CYAN}ERROR: ${RED}OS version $(lsb_release -si) - $(lsb_release -cs) not supported${NC}"
-	echo -e "${CYNA}Ubuntu 20.04 LTS is the recommended OS version... please re-image and retry installation"
-	echo -e "${WORNING} ${CYAN}Installation stopped...${NC}"
-	echo
-	exit      
+      echo -e "${WORNING} ${CYAN}ERROR: ${RED}OS version $(lsb_release -si) - $(lsb_release -cs) not supported${NC}"
+      if [[ "$avx_check" == "" && $(lsb_release -cs) == "jammy" ]]; then
+        echo -e "${WORNING} ${CYNA}AVX CPU instruction set not found and is required to use MongoDB on $(lsb_release -cs)${NC}"
+      fi
+      echo -e "${CYNA}Ubuntu 20.04 LTS is the recommended OS version... please re-image and retry installation"
+      echo -e "${WORNING} ${CYAN}Installation stopped...${NC}"
+      echo
+      exit      
     fi
   done 
 }


### PR DESCRIPTION
Provide a more detailed error message when AVX instruction flag is missing and user is on Ubuntu 22.04

MongoDB requires a CPU with AVX instruction set when using Ubuntu 22.04 (Jammy).

Minor formatting.