### PR TITLE
Development

### DIFF
--- a/flux_common.sh
+++ b/flux_common.sh
@@ -881,7 +881,7 @@ function manual_build(){
 function os_check(){
   BLACK_LIST=( "kinetic" )
   avx_check=$(cat /proc/cpuinfo | grep -o avx | head -n1)
-  if [[ "$avx_check" == "" ]]; then 
+  if [[ "$avx_check" == "" || "$(dpkg --print-architecture)" = *arm* ]]; then 
     BLACK_LIST+=( "jammy" )
   fi
   LIST_LENGTH=${#BLACK_LIST[@]}

--- a/install_pro.sh
+++ b/install_pro.sh
@@ -563,7 +563,7 @@ function install_process() {
 	avx_check=$(cat /proc/cpuinfo | grep -o avx | head -n1)
 	# AVX instruction flag not found - so install 4.4
 	# else install newest version 6.0
-	if [[ "$avx_check" == "" ]]; then
+	if [[ "$avx_check" == "" || "$(dpkg --print-architecture)" = *arm* ]]; then
 		curl -fsSL https://www.mongodb.org/static/pgp/server-4.4.asc | gpg --dearmor | sudo tee /usr/share/keyrings/mongodb-archive-keyring.gpg > /dev/null 2>&1
 		if [[ $(lsb_release -d) = *Debian* ]]; then 
 			echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/mongodb-archive-keyring.gpg] https://repo.mongodb.org/apt/debian $(lsb_release -cs)/mongodb-org/4.4 main" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.4.list > /dev/null 2>&1


### PR DESCRIPTION
MongoDB 5.0+ requires ARM v8.2-A or later and the Raspberry Pi 4 uses an [ARM Cortex-A72 4](https://en.wikipedia.org/wiki/ARM_Cortex-A72) which is ARM v8-A.
Unfortunately this means the pre-built packages for MongoDB 5.0 will not support Raspberry Pi 4.
Missing CCFLAGS-march=armv8.

- updated os check for arch conditional
