### PR TITLE
UPnP Setup Before Option 2

### DIFF
--- a/flux_common.sh
+++ b/flux_common.sh
@@ -2290,20 +2290,25 @@ function upnp_enable() {
 			sudo ufw allow from $router_ip to any proto udp > /dev/null 2>&1
 		fi
 	fi
-	sudo systemctl restart zelcash  > /dev/null 2>&1
-	pm2 restart flux  > /dev/null 2>&1
-	sleep 150
-	echo -e "${ARROW}${CYAN} Checking FluxOS logs... ${NC}"
-	error_check=$(tail -n10 /home/$USER/.pm2/logs/flux-out.log | grep "UPnP failed")
-	if [[ "$error_check" == "" ]]; then
-		echo -e ""
-		LOCAL_IP=$(ip -o route get to 8.8.8.8 | sed -n 's/.*src \([0-9.]\+\).*/\1/p')
-		ZELFRONTPORT=$(($FLUX_PORT-1))
-		echo -e "${PIN} ${CYAN}To access your FluxOS use this url: ${SEA}http://${LOCAL_IP}:$ZELFRONTPORT${NC}"
-		echo -e ""
+	if [[ "$1" != "install" ]]; then
+		sudo systemctl restart zelcash  > /dev/null 2>&1
+		pm2 restart flux  > /dev/null 2>&1
+		sleep 150
+		echo -e "${ARROW}${CYAN} Checking FluxOS logs... ${NC}"
+		error_check=$(tail -n10 /home/$USER/.pm2/logs/flux-out.log | grep "UPnP failed")
+		if [[ "$error_check" == "" ]]; then
+			echo -e ""
+			LOCAL_IP=$(ip -o route get to 8.8.8.8 | sed -n 's/.*src \([0-9.]\+\).*/\1/p')
+			ZELFRONTPORT=$(($FLUX_PORT-1))
+			echo -e "${PIN} ${CYAN}To access your FluxOS use this url: ${SEA}http://${LOCAL_IP}:$ZELFRONTPORT${NC}"
+			echo -e ""
+		else
+			echo -e "${WORNING} ${RED}Problem with UPnP detected, FluxOS Shutting down...${NC}"
+			echo -e ""
+		fi
 	else
-		echo -e "${WORNING} ${RED}Problem with UPnP detected, FluxOS Shutting down...${NC}"
-		echo -e ""
+			LOCAL_IP=$(ip -o route get to 8.8.8.8 | sed -n 's/.*src \([0-9.]\+\).*/\1/p')
+			ZELFRONTPORT=$(($FLUX_PORT-1))
 	fi
 }
 #### TESTNET

--- a/flux_common.sh
+++ b/flux_common.sh
@@ -1007,20 +1007,6 @@ function string_limit_check_mark() {
 	fi
 	echo -e "${ARROW} ${CYAN}$string[${CHECK_MARK}${CYAN}]${NC}"
 }
-function spinning_timer() {
-	animation=( ⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏ )
-	end=$((SECONDS+NUM))
-	while [ $SECONDS -lt $end ];
-	do
-		for i in "${animation[@]}";
-		do
-		echo -e ""
-			echo -ne "${RED}\r\033[1A\033[0K$i ${CYAN}${MSG1}${NC}"
-			sleep 0.1
-		done
-	done
-	echo -ne "${MSG2}"
-}
 function integration_check() {
 	FILE_ARRAY=( 'fluxbench-cli' 'fluxbenchd' 'flux-cli' 'fluxd' 'flux-fetch-params.sh' 'flux-tx' )
 	ELEMENTS=${#FILE_ARRAY[@]}

--- a/flux_common.sh
+++ b/flux_common.sh
@@ -1970,7 +1970,7 @@ function finalizing() {
 	
 	if [[ "$gateway_ip" != "" && "$upnp_port" != "" ]] && [[ "$upnp_port" != "null" ]] ; then
 	  error_check=$(tail -n10 /home/$USER/.pm2/logs/flux-out.log | grep "UPnP failed")
-          if [[ "$error_check" == "" ]]; then
+          if [[ "$error_check" != "" ]]; then
 	    echo -e "${WORNING} ${RED}Problem with UPnP detected, FluxOS Shutting down...${NC}"
 	    echo -e ""
 	  fi

--- a/flux_common.sh
+++ b/flux_common.sh
@@ -1967,6 +1967,15 @@ function finalizing() {
 	MSG2="${CYAN}.............[${CHECK_MARK}${CYAN}]${NC}"
 	echo && spinning_timer
 	echo 
+	
+	if [[ "$gateway_ip" != "" && "$upnp_port" != "" ]] && [[ "$upnp_port" != "null" ]] ; then
+	  error_check=$(tail -n10 /home/$USER/.pm2/logs/flux-out.log | grep "UPnP failed")
+          if [[ "$error_check" == "" ]]; then
+	    echo -e "${WORNING} ${RED}Problem with UPnP detected, FluxOS Shutting down...${NC}"
+	    echo -e ""
+	  fi
+	fi
+	
 	$BENCH_CLI restartnodebenchmarks  > /dev/null 2>&1
 	NUM='300'
 	MSG1='Restarting benchmark...'

--- a/install_pro.sh
+++ b/install_pro.sh
@@ -682,8 +682,8 @@ if [[ "$thunder" == "1" ]]; then
 	echo -e "${ARROW} ${YELLOW}Thunder Mode configuration...${NC}"
 	thunder_mode "install"
 fi
-finalizing
 if [[ "$gateway_ip" != "" && "$upnp_port" != "" ]] && [[ "$upnp_port" != "null" ]] ; then
-	upnp_enable
+	upnp_enable "install"
 fi
+finalizing
 display_banner

--- a/multitoolbox.sh
+++ b/multitoolbox.sh
@@ -517,7 +517,7 @@ function install_node(){
 	
 	if [[ $(lsb_release -d) != *Debian* && $(lsb_release -d) != *Ubuntu* ]]; then
 		echo -e "${WORNING} ${CYAN}ERROR: ${RED}OS version $(lsb_release -si) not supported${NC}"
-		eecho -e "${CYNA}Ubuntu 20.04 LTS is the recommended OS version .. please re-image and retry installation"
+		echo -e "${CYNA}Ubuntu 20.04 LTS is the recommended OS version .. please re-image and retry installation"
 		echo -e "${WORNING} ${CYAN}Installation stopped...${NC}"
 		echo
 		exit

--- a/multitoolbox.sh
+++ b/multitoolbox.sh
@@ -719,7 +719,17 @@ function mongod_db_fix() {
 			sudo rm -r /var/log/mongodb > /dev/null 2>&1
 			sudo rm -r /var/lib/mongodb > /dev/null 2>&1
 			echo -e "${ARROW} ${CYAN}Installing MongoDB... ${NC}"
-			sudo apt install mongodb-org -y > /dev/null 2>&1
+		        avx_check=$(cat /proc/cpuinfo | grep -o avx | head -n1)
+                        if [[ "$avx_check" == "" ]]; then
+	                  sudo apt install -y mongodb-org=4.4.18 mongodb-org-server=4.4.18 mongodb-org-shell=4.4.18 mongodb-org-mongos=4.4.18 mongodb-org-tools=4.4.18 > /dev/null 2>&1 && sleep 2
+	                  echo "mongodb-org hold" | sudo dpkg --set-selections > /dev/null 2>&1 && sleep 2
+                          echo "mongodb-org-server hold" | sudo dpkg --set-selections > /dev/null 2>&1 
+                          echo "mongodb-org-shell hold" | sudo dpkg --set-selections > /dev/null 2>&1 
+                          echo "mongodb-org-mongos hold" | sudo dpkg --set-selections > /dev/null 2>&1 
+                          echo "mongodb-org-tools hold" | sudo dpkg --set-selections > /dev/null 2>&1 
+	                else
+	                  sudo apt install -y mongodb-org > /dev/null 2>&1 
+	                fi
 			sudo mkdir -p /var/log/mongodb > /dev/null 2>&1
 			sudo mkdir -p /var/lib/mongodb > /dev/null 2>&1
 			echo -e "${ARROW} ${CYAN}Settings privilege... ${NC}"


### PR DESCRIPTION
Setup UPnP before starting Flux OS during option 2 installation.

- Requires option 6 to be ran to create an install_conf file with the required UPnP details, prior to running option 2.
- Will reduce failed benchmark pings because of a node already using the default port
- Ensures UPnP networking rules are setup before trying to start Flux OS
- Speeds up install time because it doesn't have to rely on the benchmark to restart

In future installation guides it is recommended to run option 6 prior to running option 2. This helps ensure that the user has all details for the install and answers all related questions prior to starting the node installation.