### PR TITLE
Fix typo in flux_common.sh (/dev/null)

### DIFF
--- a/flux_common.sh
+++ b/flux_common.sh
@@ -974,9 +974,9 @@ function manual_build(){
 
 		index_from_file="$index"
 		tx_from_file="$outpoint"
-		stak_info=$(curl -sSL -m 5 https://$network_url_1/api/tx/$tx_from_file | jq -r ".vout[$index_from_file] | .value,.n,.scriptPubKey.addresses[0],.spentTxId" 2> /dev/nul | paste - - - - | awk '{printf "%0.f %d %s %s\n",$1,$2,$3,$4}' | grep 'null' | egrep -o '1000|12500|40000')
+		stak_info=$(curl -sSL -m 5 https://$network_url_1/api/tx/$tx_from_file | jq -r ".vout[$index_from_file] | .value,.n,.scriptPubKey.addresses[0],.spentTxId" 2> /dev/null | paste - - - - | awk '{printf "%0.f %d %s %s\n",$1,$2,$3,$4}' | grep 'null' | egrep -o '1000|12500|40000')
 		if [[ "$stak_info" == "" ]]; then
-			stak_info=$(curl -sSL -m 5 https://$network_url_2/api/tx/$tx_from_file | jq -r ".vout[$index_from_file] | .value,.n,.scriptPubKey.addresses[0],.spentTxId" 2> /dev/nul | paste - - - - | awk '{printf "%0.f %d %s %s\n",$1,$2,$3,$4}' | grep 'null' | egrep -o '1000|12500|40000')
+			stak_info=$(curl -sSL -m 5 https://$network_url_2/api/tx/$tx_from_file | jq -r ".vout[$index_from_file] | .value,.n,.scriptPubKey.addresses[0],.spentTxId" 2> /dev/null | paste - - - - | awk '{printf "%0.f %d %s %s\n",$1,$2,$3,$4}' | grep 'null' | egrep -o '1000|12500|40000')
 		fi	
 		if [[ $stak_info == ?(-)+([0-9]) ]]; then
 			case $stak_info in


### PR DESCRIPTION
Simple fix

![Screenshot 2024-02-07 at 4 23 18 PM](https://github.com/RunOnFlux/fluxnode-multitool/assets/22514713/e0287cd7-31f2-45b0-aaa4-2122e9cbfc90)
