### PR TITLE
Feature: allow non gzipped tar bootstraps

### DIFF
--- a/flux_common.sh
+++ b/flux_common.sh
@@ -1924,7 +1924,7 @@ function bootstrap_manual() {
 }
 function bootstrap_local() {
 	local BOOTSTRAP_STEM="flux_explorer_bootstrap"
-	local BOOTSTRAP_FILES=($(ls $BOOTSTRAP_STEM.{tar,tar.gz} 2>/dev/null))
+	local BOOTSTRAP_FILES=($(ls /home/$USER/$BOOTSTRAP_STEM.{tar,tar.gz} 2>/dev/null))
 
 	if [ "$BOOTSTRAP_FILES" -a ${#BOOTSTRAP_FILES[@]} ]; then
 		# we take the first bootstrap file

--- a/flux_common.sh
+++ b/flux_common.sh
@@ -1708,12 +1708,18 @@ function fluxos_reconfiguration {
 }
 ######### BOOTSTRAP SECTION ############################
 function tar_file_unpack() {
-	echo -e "${ARROW} ${CYAN}Unpacking wallet bootstrap please be patient...${NC}"
-	pv $1 | tar -zx -C $2
+	local TARFILE=$1
+	local DEST_DIR=$2
+	local MIME_TYPE=$(file -b --mime-type $TARFILE)
+	local GZIP=""
+	# tar is application/x-tar
+	[[ "$MIME_TYPE" == "application/gzip" ]] && GZIP="-z"
+	echo -e "${ARROW} ${CYAN}Unpacking daemon bootstrap please be patient...${NC}"
+	pv $TARFILE | tar $GZIP -x -C $DEST_DIR
 }
 function check_tar() {
 	echo -e "${ARROW} ${CYAN}Checking file integrity...${NC}"
-	if gzip -t "$1" &>/dev/null; then
+	if tar -tf "$1" &>/dev/null; then
 		echo -e "${ARROW} ${CYAN}Bootstrap file is valid.................[${CHECK_MARK}${CYAN}]${NC}"
 	else
 		echo -e "${ARROW} ${CYAN}Bootstrap file is corrupted.............[${X_MARK}${CYAN}]${NC}"
@@ -1917,9 +1923,12 @@ function bootstrap_manual() {
 	esac
 }
 function bootstrap_local() {
-	BOOTSTRAP_FILE="flux_explorer_bootstrap.tar.gz"
-	FILE_PATH="/home/$USER/$BOOTSTRAP_FILE"
-	if [ -f "$FILE_PATH" ]; then
+	local BOOTSTRAP_STEM="flux_explorer_bootstrap"
+	local BOOTSTRAP_FILES=($(ls $BOOTSTRAP_STEM.{tar,tar.gz} 2>/dev/null))
+
+	if [ "$BOOTSTRAP_FILES" -a ${#BOOTSTRAP_FILES[@]} ]; then
+		# we take the first bootstrap file
+		FILE_PATH="/home/$USER/$BOOTSTRAP_FILES"
 		echo -e "${ARROW} ${CYAN}Local bootstrap file detected...${NC}"
 		check_tar "$FILE_PATH"
 		if [ -f "$FILE_PATH" ]; then


### PR DESCRIPTION
The `flux/streamchain` fluxOS endpoint now allows non gzipped bootstrap tarfiles to be downloaded.

This pull modifies `bootstrap_local` (and others) slightly so the following will work:

* Installer looks for either `flux_explorer_bootstrap.tar` or `flux_explorer_bootstrap.tar.gz`
* Instead of checking the file with `gzip -t` we use `tar -tf` which accepts both uncompressed / compressed.
* Use the file mime-type to determine what switch to use for `tar_unpack`

Checking the tar archive as well as gzip is only marginally slower:

```
davew@cindy:~$ time gzip -t flux_explorer_bootstrap.tar.gz

real	3m29.277s
user	2m54.169s
sys	0m24.258s

davew@cindy:~$ time tar -tf flux_explorer_bootstrap.tar.gz &> /dev/null

real	4m2.019s
user	3m19.116s
sys	0m57.999s
```