### PR TITLE
Bugfix - Using local bootstrap

### DIFF
--- a/flux_common.sh
+++ b/flux_common.sh
@@ -1933,7 +1933,7 @@ function bootstrap_local() {
 
 	if [ "$BOOTSTRAP_FILES" -a ${#BOOTSTRAP_FILES[@]} ]; then
 		# we take the first bootstrap file
-		FILE_PATH="/home/$USER/$BOOTSTRAP_FILES"
+		FILE_PATH="$BOOTSTRAP_FILES"
 		echo -e "${ARROW} ${CYAN}Local bootstrap file detected...${NC}"
 		check_tar "$FILE_PATH"
 		if [ -f "$FILE_PATH" ]; then


### PR DESCRIPTION
Fixes an issue where we were prepending the user's homedir to the path again - so `local_bootstrap` didn't work

```
	local BOOTSTRAP_FILES=($(ls /home/$USER/$BOOTSTRAP_STEM.{tar,tar.gz} 2>/dev/null))
```

This already has the absolute file path. I mistakenly added this after I'd already tested on the last pull. 