### PR TITLE
Pull repo on development mode change

### DIFF
--- a/flux_common.sh
+++ b/flux_common.sh
@@ -1647,13 +1647,13 @@ function development_mode(){
     echo -e "${ARROW}${GREEN} [FluxOS] ${CYAN}Enabling development mode... ${NC}"
     config_builder "development" "true" "Development Mode" "fluxos"
     cd $HOME/$FLUX_DIR
-    git checkout development > /dev/null 2>&1
+    git checkout development && git pull > /dev/null 2>&1
     pm2 restart flux > /dev/null 2>&1
   else
     echo -e "${ARROW}${GREEN} [FluxOS] ${CYAN}Disabling development mode... ${NC}"
     config_builder "development" "false" "Development Mode" "fluxos"
     cd $HOME/$FLUX_DIR
-    git checkout master > /dev/null 2>&1
+    git checkout master && git pull > /dev/null 2>&1
     pm2 restart flux > /dev/null 2>&1
   fi
 }


### PR DESCRIPTION
When changing to / from dev mode, it's not pulling the branch. If the user has a local copy of the branch already, they will use the stale branch.

It then takes 20 minutes to update to latest settings.

This changes just makes sure the user is on the latest version when switching.

See below, I changed to dev mode but had a stale branch, from a month ago:

![Screenshot 2024-08-10 at 9 33 30 AM](https://github.com/user-attachments/assets/81c4f565-8d01-4666-84f5-5f23eaccb03a)
